### PR TITLE
refactor: centralize post types

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Header from "../components/Header";
-import PostCard, { Post } from "../components/PostCard";
+import PostCard from "../components/PostCard";
 import StoryDeckModal from "../components/StoryDeckModal";
 import { posts as samplePosts } from "../data/posts";
 import { useState, useMemo } from "react";
@@ -9,6 +9,7 @@ import CategoryFilter, { Category } from "../components/CategoryFilter";
 import SkeletonCard from "../components/SkeletonCard";
 import { useInfinite } from "../hooks/useInfinite";
 import { motion } from "framer-motion";
+import type { Post } from "../types/post";
 
 export default function Page() {
   const [open, setOpen] = useState(false);

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -3,9 +3,7 @@ import Image from "next/image";
 import { categoryColor } from "../lib/colors";
 import { BLUR_SVG } from "../lib/blur";
 import { motion } from "framer-motion";
-
-export type Slide = { type:'image'|'video'|'text'; src?:string; alt?:string; title?:string; subtitle?:string; };
-export type Post = { id:string; category:string; title:string; subtitle:string; image:string; slides: Slide[]; article?: string; };
+import type { Post } from "../types/post";
 
 export default function PostCard({ post, onOpen }: { post: Post; onOpen: (post: Post) => void; }) {
   const catColor = categoryColor(post.category);

--- a/components/StoryDeckModal.tsx
+++ b/components/StoryDeckModal.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useState } from "react";
-import type { Post } from "./PostCard";
+import type { Post } from "../types/post";
 import Image from "next/image";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Pagination, Keyboard, A11y, Mousewheel, EffectCreative, Parallax } from "swiper/modules";

--- a/data/posts.ts
+++ b/data/posts.ts
@@ -1,4 +1,4 @@
-import type { Post } from "../components/PostCard";
+import type { Post } from "../types/post";
 
 export const posts: Post[] = [
   {

--- a/types/post.ts
+++ b/types/post.ts
@@ -1,0 +1,17 @@
+export interface Slide {
+  type: 'image' | 'video' | 'text';
+  src?: string;
+  alt?: string;
+  title?: string;
+  subtitle?: string;
+}
+
+export interface Post {
+  id: string;
+  category: string;
+  title: string;
+  subtitle: string;
+  image: string;
+  slides: Slide[];
+  article?: string;
+}


### PR DESCRIPTION
## Summary
- extract shared `Post` and `Slide` interfaces to `types/post.ts`
- update components and data to use new post types module

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b10347ea7c8326b7c08a30f6a0290a