### PR TITLE
refactor: centralize category definitions

### DIFF
--- a/components/CategoryFilter.tsx
+++ b/components/CategoryFilter.tsx
@@ -1,7 +1,10 @@
 "use client";
-export type Category = "Tudo" | "Cultura" | "Gastronomia" | "Esporte" | "Turismo";
+import { categories } from "../lib/categories";
+
+export type Category = "Tudo" | (typeof categories)[number];
+
 export default function CategoryFilter({ value, onChange }: { value: Category; onChange: (c: Category)=>void; }){
-  const cats: Category[] = ["Tudo","Cultura","Gastronomia","Esporte","Turismo"];
+  const cats: Category[] = ["Tudo", ...categories];
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {cats.map(c => (

--- a/data/posts.ts
+++ b/data/posts.ts
@@ -1,6 +1,11 @@
 import type { Post } from "../types/post";
+import type { Category } from "../lib/categories";
 
-export const posts: Post[] = [
+interface PostData extends Omit<Post, "category"> {
+  category: Category;
+}
+
+export const posts: PostData[] = [
   {
     id: "p01",
     category: "Cultura",
@@ -11,7 +16,7 @@ export const posts: Post[] = [
       { type: "image", src: "https://images.unsplash.com/photo-1519681393784-d120267933ba?q=80&w=1200&auto=format&fit=crop", title: "Palco principal", subtitle: "Atrações a partir das 18h" },
       { type: "image", src: "https://images.unsplash.com/photo-1461749280684-dccba630e2f6?q=80&w=1200&auto=format&fit=crop", title: "Mostra de curtas", subtitle: "Cinema na praça" }
     ],
-    article: "O Festival de Inverno reúne artistas locais e visitantes..."
+    article: "O Festival de Inverno reúne artistas locais e visitantes...",
   },
   {
     id: "p02",
@@ -23,7 +28,7 @@ export const posts: Post[] = [
       { type: "image", src: "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?q=80&w=1200&auto=format&fit=crop", title: "Notas frutadas", subtitle: "Degustação guiada" },
       { type: "image", src: "https://images.unsplash.com/photo-1517705008128-361805f42e86?q=80&w=1200&auto=format&fit=crop", title: "Métodos filtrados", subtitle: "V60, Aeropress e mais" }
     ],
-    article: "O roteiro do café especial passa por torrefações artesanais..."
+    article: "O roteiro do café especial passa por torrefações artesanais...",
   },
   {
     id: "p03",
@@ -34,7 +39,7 @@ export const posts: Post[] = [
     slides: [
       { type: "image", src: "https://images.unsplash.com/photo-1477414348463-c0eb7f1359b6?q=80&w=1200&auto=format&fit=crop", title: "Circuito das águas", subtitle: "Nível moderado" }
     ],
-    article: "As trilhas do Rio Peixe revelam paisagens pouco conhecidas..."
+    article: "As trilhas do Rio Peixe revelam paisagens pouco conhecidas...",
   },
   {
     id: "p04",
@@ -45,7 +50,7 @@ export const posts: Post[] = [
     slides: [
       { type: "image", src: "https://images.unsplash.com/photo-1509395176047-4a66953fd231?q=80&w=1200&auto=format&fit=crop", title: "Clássico municipal", subtitle: "Ingressos populares" }
     ],
-    article: "A Copa Regional atrai equipes de toda a região..."
+    article: "A Copa Regional atrai equipes de toda a região...",
   },
   {
     id: "p05",
@@ -56,7 +61,7 @@ export const posts: Post[] = [
     slides: [
       { type: "image", src: "https://images.unsplash.com/photo-1529101091764-c3526daf38fe?q=80&w=1200&auto=format&fit=crop", title: "Autores locais", subtitle: "Sessão de autógrafos" }
     ],
-    article: "A feira reúne editoras e autores independentes..."
+    article: "A feira reúne editoras e autores independentes...",
   },
   {
     id: "p06",
@@ -67,7 +72,7 @@ export const posts: Post[] = [
     slides: [
       { type: "image", src: "https://images.unsplash.com/photo-1472148083604-64f1084980b6?q=80&w=1200&auto=format&fit=crop", title: "Anos 30 e 40", subtitle: "Passeio guiado" }
     ],
-    article: "O roteiro destaca fachadas e histórias curiosas..."
+    article: "O roteiro destaca fachadas e histórias curiosas...",
   },
   {
     id: "p07",
@@ -78,7 +83,7 @@ export const posts: Post[] = [
     slides: [
       { type: "image", src: "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?q=80&w=1200&auto=format&fit=crop", title: "Pastéis doces", subtitle: "Experimente novidades" }
     ],
-    article: ""
+    article: "",
   },
   {
     id: "p08",
@@ -87,7 +92,7 @@ export const posts: Post[] = [
     subtitle: "Inscrições abertas",
     image: "https://images.unsplash.com/photo-1519681393784-d120267933ba?q=80&w=1200&auto=format&fit=crop",
     slides: [],
-    article: ""
+    article: "",
   },
   {
     id: "p09",
@@ -96,7 +101,7 @@ export const posts: Post[] = [
     subtitle: "Grupos convidados",
     image: "https://images.unsplash.com/photo-1461749280684-dccba630e2f6?q=80&w=1200&auto=format&fit=crop",
     slides: [],
-    article: ""
+    article: "",
   },
   {
     id: "p10",
@@ -105,7 +110,7 @@ export const posts: Post[] = [
     subtitle: "Mirantes e cafés",
     image: "https://images.unsplash.com/photo-1477414348463-c0eb7f1359b6?q=80&w=1200&auto=format&fit=crop",
     slides: [],
-    article: ""
+    article: "",
   },
   {
     id: "p11",
@@ -114,7 +119,7 @@ export const posts: Post[] = [
     subtitle: "Roteiro de feirinhas",
     image: "https://images.unsplash.com/photo-1517705008128-361805f42e86?q=80&w=1200&auto=format&fit=crop",
     slides: [],
-    article: ""
+    article: "",
   },
   {
     id: "p12",
@@ -123,6 +128,6 @@ export const posts: Post[] = [
     subtitle: "Pedal coletivo domingo",
     image: "https://images.unsplash.com/photo-1509395176047-4a66953fd231?q=80&w=1200&auto=format&fit=crop",
     slides: [],
-    article: ""
+    article: "",
   }
 ];

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,15 @@
+export const categories = [
+  "Cultura",
+  "Gastronomia",
+  "Esporte",
+  "Turismo",
+] as const;
+
+export type Category = typeof categories[number];
+
+export const categoryColors: Record<Category, string> = {
+  Cultura: "#FF7A1A",
+  Gastronomia: "#F04438",
+  Esporte: "#0E3AAF",
+  Turismo: "#16A34A",
+};

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,9 +1,5 @@
+import { categoryColors } from "./categories";
+
 export function categoryColor(cat: string){
-  switch(cat){
-    case "Cultura": return "#FF7A1A";
-    case "Gastronomia": return "#F04438";
-    case "Esporte": return "#0E3AAF";
-    case "Turismo": return "#16A34A";
-    default: return "#64748B";
-  }
+  return categoryColors[cat as keyof typeof categoryColors] ?? "#64748B";
 }


### PR DESCRIPTION
## Summary
- centralize category names and their colors in a new module
- consume shared categories in filter component and color helper
- type posts with shared categories

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(blocked: requires interactive setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b104f669308326bbed1ec5473bba62