### PR TITLE
Replace alerts with accessible toast notifications

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import Script from "next/script";
 import { inter, poppins } from "./fonts";
+import ToastProvider from "../components/ToastProvider";
 
 export const metadata: Metadata = {
   title: "ComMarília",
@@ -30,7 +31,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlash }} />
       </head>
       <body>
-        <div className="mx-auto w-full max-w-6xl">{children}</div>
+        <ToastProvider>
+          <div className="mx-auto w-full max-w-6xl">{children}</div>
+        </ToastProvider>
         <Script id="sw-register" strategy="afterInteractive">{`
           if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
             navigator.serviceWorker.register('/sw.js').catch(()=>{});

--- a/components/ShareRow.tsx
+++ b/components/ShareRow.tsx
@@ -1,14 +1,21 @@
 "use client";
-export default function ShareRow({ title }: { title: string }){
+import { useToast } from "./ToastProvider";
+
+export default function ShareRow({ title }: { title: string }) {
+  const toast = useToast();
   const share = async () => {
     const url = typeof window !== "undefined" ? window.location.href : "";
     try {
-      if (navigator.share) await navigator.share({ title, url });
-      else {
+      if (navigator.share) {
+        await navigator.share({ title, url });
+        toast("Link compartilhado!", "success");
+      } else {
         await navigator.clipboard.writeText(url);
-        alert("Link copiado!");
+        toast("Link copiado!", "success");
       }
-    } catch {}
+    } catch {
+      toast("Não foi possível compartilhar o link", "error");
+    }
   };
   return (
     <div className="mt-4 flex items-center gap-2">

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { createContext, useContext, useState, useCallback, useRef, useEffect } from 'react';
+
+interface Toast {
+  message: string;
+  type: 'success' | 'error';
+}
+
+const ToastContext = createContext<(message: string, type?: 'success' | 'error') => void>(() => {});
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+export default function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toast, setToast] = useState<Toast | null>(null);
+  const timeout = useRef<NodeJS.Timeout>();
+  const toastRef = useRef<HTMLDivElement>(null);
+
+  const show = useCallback((message: string, type: 'success' | 'error' = 'success') => {
+    clearTimeout(timeout.current);
+    setToast({ message, type });
+    timeout.current = setTimeout(() => setToast(null), 3000);
+  }, []);
+
+  useEffect(() => {
+    if (toast) {
+      toastRef.current?.focus();
+    }
+  }, [toast]);
+
+  return (
+    <ToastContext.Provider value={show}>
+      {children}
+      {toast && (
+        <div
+          ref={toastRef}
+          role={toast.type === 'error' ? 'alert' : 'status'}
+          aria-live={toast.type === 'error' ? 'assertive' : 'polite'}
+          tabIndex={-1}
+          className={`fixed bottom-4 left-1/2 -translate-x-1/2 rounded px-4 py-2 text-white shadow-lg focus:outline-none ${toast.type === 'error' ? 'bg-red-600' : 'bg-green-600'}`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </ToastContext.Provider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ToastProvider to layout
- replace alert in ShareRow with toast success/error messages
- implement accessible toast component with ARIA roles and focus

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (cannot run: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68b104f736a083269d64bfecf1ffc8bc