### PR TITLE
Stop observing once all items loaded

### DIFF
--- a/hooks/useInfinite.ts
+++ b/hooks/useInfinite.ts
@@ -7,9 +7,13 @@ export function useInfinite<T>(all: T[], step = 9){
   useEffect(() => {
     const el = ref.current;
     if(!el) return;
-    const ob = new IntersectionObserver((entries)=>{
-      entries.forEach(e=>{
-        if(e.isIntersecting) setLimit(l => Math.min(l + step, all.length));
+    const ob = new IntersectionObserver((entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting)
+          setLimit((l) => {
+            if (l + step >= all.length) ob.unobserve(el);
+            return Math.min(l + step, all.length);
+          });
       });
     });
     ob.observe(el);


### PR DESCRIPTION
## Summary
- stop intersection observer when all items are loaded

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b10735231083269b72e59dcec229ab