### PR TITLE
refactor: add CategoryFilterValue type

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import PostCard from "../components/PostCard";
 import StoryDeckModal from "../components/StoryDeckModal";
 import { posts as samplePosts } from "../data/posts";
 import { useState, useMemo } from "react";
-import CategoryFilter, { Category } from "../components/CategoryFilter";
+import CategoryFilter, { CategoryFilterValue } from "../components/CategoryFilter";
 import SkeletonCard from "../components/SkeletonCard";
 import { useInfinite } from "../hooks/useInfinite";
 import { motion } from "framer-motion";
@@ -14,7 +14,7 @@ import type { Post } from "../types/post";
 export default function Page() {
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number>(0);
-  const [cat, setCat] = useState<Category>("Tudo");
+  const [cat, setCat] = useState<CategoryFilterValue>("Tudo");
 
   const posts = samplePosts.slice(2);
 

--- a/components/CategoryFilter.tsx
+++ b/components/CategoryFilter.tsx
@@ -1,10 +1,10 @@
 "use client";
-import { categories } from "../lib/categories";
+import { categories, type Category } from "../lib/categories";
 
-export type Category = "Tudo" | (typeof categories)[number];
+export type CategoryFilterValue = "Tudo" | Category;
 
-export default function CategoryFilter({ value, onChange }: { value: Category; onChange: (c: Category)=>void; }){
-  const cats: Category[] = ["Tudo", ...categories];
+export default function CategoryFilter({ value, onChange }: { value: CategoryFilterValue; onChange: (c: CategoryFilterValue)=>void; }){
+  const cats: CategoryFilterValue[] = ["Tudo", ...categories];
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {cats.map(c => (


### PR DESCRIPTION
## Summary
- use Category from lib to create local CategoryFilterValue union
- update page to import and use CategoryFilterValue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b10737af74832694b6cf15b8f55918