### PR TITLE
Expose subset helper for posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ npm install
 3. O hook `useInfinite` carrega mais cards conforme o usuário rola a página.
 4. Cada card (`PostCard`) abre o `StoryDeckModal`, que apresenta as imagens e textos do post em um carrossel vertical no estilo "stories".
 
+### Subconjunto de posts
+
+Caso seja necessário trabalhar apenas com parte da lista, a função `getPosts(start, end)` exportada de `data/posts.ts` permite informar o intervalo desejado.
+
 ## Adicionando novos posts ou categorias
 
 ### Novos posts

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,9 @@ export default function Page() {
   const [activeIndex, setActiveIndex] = useState<number>(0);
   const [cat, setCat] = useState<Category>("Tudo");
 
-  const posts = samplePosts.slice(2);
+  // Use the entire list of sample posts by default.
+  // To show a subset, use getPosts(start, end) from `data/posts`.
+  const posts = samplePosts;
 
   const filtered = useMemo(() => {
     if (cat === "Tudo") return posts;

--- a/data/posts.ts
+++ b/data/posts.ts
@@ -131,3 +131,14 @@ export const posts: PostData[] = [
     article: "",
   }
 ];
+
+/**
+ * Retrieve sample posts.
+ *
+ * @param start - Index of the first post to include (inclusive).
+ * @param end - Index after the last post to include (exclusive).
+ * @returns A slice of the sample posts array.
+ */
+export function getPosts(start = 0, end = posts.length): PostData[] {
+  return posts.slice(start, end);
+}


### PR DESCRIPTION
## Summary
- display all sample posts by default
- add `getPosts` helper to fetch subsets of the sample data
- document subset usage in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b1073af9a08326b9c11b664c6bd1fc