### PR TITLE
feat: allow stable IDs for blur placeholders

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -25,7 +25,7 @@ export default function PostCard({ post, onOpen }: { post: Post; onOpen: (post: 
           className="object-cover transition-transform duration-300 group-hover:scale-105"
           sizes="(max-width:768px) 100vw, 33vw"
           placeholder="blur"
-          blurDataURL={BLUR_SVG()}
+          blurDataURL={BLUR_SVG(8, 8, post.id)}
         />
         <div className="overlay-gradient absolute inset-0"></div>
       </div>

--- a/lib/blur.ts
+++ b/lib/blur.ts
@@ -1,6 +1,8 @@
-export const BLUR_SVG = (w = 8, h = 8) => {
-  const id = Math.random().toString(36).slice(2);
-  return `data:image/svg+xml;charset=utf-8,` + encodeURIComponent(
-    `<svg xmlns='http://www.w3.org/2000/svg' width='${w}' height='${h}' viewBox='0 0 ${w} ${h}'><defs><linearGradient id='g${id}' x1='0' y1='0' x2='1' y2='1'><stop stop-color='#0E3AAF' offset='0'/><stop stop-color='#FF7A1A' offset='1'/></linearGradient></defs><rect fill='url(%23g${id})' width='${w}' height='${h}'/></svg>`
+export const BLUR_SVG = (w = 8, h = 8, id = "g") => {
+  return (
+    `data:image/svg+xml;charset=utf-8,` +
+    encodeURIComponent(
+      `<svg xmlns='http://www.w3.org/2000/svg' width='${w}' height='${h}' viewBox='0 0 ${w} ${h}'><defs><linearGradient id='${id}' x1='0' y1='0' x2='1' y2='1'><stop stop-color='#0E3AAF' offset='0'/><stop stop-color='#FF7A1A' offset='1'/></linearGradient></defs><rect fill='url(%23${id})' width='${w}' height='${h}'/></svg>`
+    )
   );
 };


### PR DESCRIPTION
## Summary
- allow passing an optional ID to BLUR_SVG instead of using Math.random
- pass post ID to BLUR_SVG in PostCard for stable blur placeholder

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=true npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b10731ffb88326983905d0db3c954d